### PR TITLE
Improve sample to demonstrate branch increase after kotlin upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,3 +39,9 @@ tasks.test {
         "java.awt.headless", "true"
     )
 }
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required.set(true)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.4.10"
 compose = "1.10.3"
 junit5 = "5.11.4"
 

--- a/src/main/kotlin/org/example/Example.kt
+++ b/src/main/kotlin/org/example/Example.kt
@@ -4,15 +4,20 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 
+data class State(val titles: List<String>)
+
 @Composable
-fun example() {
+fun example(state: State, onDone: () -> Unit = {}) {
     var counter by remember { mutableStateOf(0) }
     if (counter == 2) {
         return
     }
-    Button(onClick = { counter++ }) {
+    Button(onClick = {
+        if (counter == 1 && state.titles.isNotEmpty()) onDone()
+        counter++
+    }) {
         if (counter == 0) {
-            Text("Click me")
+            Text("Click me ${state.titles.first()}")
         } else {
             Text("Click me again")
         }

--- a/src/test/kotlin/org/example/ExampleTest.kt
+++ b/src/test/kotlin/org/example/ExampleTest.kt
@@ -14,11 +14,11 @@ class ExampleTest {
     @Test
     fun test() {
         compose.setContent {
-            example()
+            example(state = State(listOf("now")))
         }
-        compose.onNodeWithText("Click me").performClick()
+        compose.onNodeWithText("Click me now").performClick()
         compose.onNodeWithText("Click me again").performClick()
-        compose.onNodeWithText("Click me").assertDoesNotExist()
+        compose.onNodeWithText("Click me now").assertDoesNotExist()
         compose.onNodeWithText("Click me again").assertDoesNotExist()
     }
 


### PR DESCRIPTION
Upgrading Kotlin 2.3.21 → 2.4.10 changes the JaCoCo branch count for identical source and test:

| Kotlin | branches covered/total |
| ------ | ---------------------- |
| 2.3.21 | 10/14 (71.4%)          |
| 2.4.10 | 14/20 (70.0%)          |

The extra branches appear on the `Button(onClick = {` line: the Kotlin 2.4 Compose compiler generates different bytecode Reproduce by switching `kotlin` between 2.3.21 and 2.4.10 and run `./gradlew test jacocoTestReport`.

This effect cause big drop in branch coverage in our main project. 